### PR TITLE
Follow structure in Laravel 6

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -215,7 +215,7 @@ class Factory implements ArrayAccess
 
         if (is_dir($path)) {
             foreach (Finder::create()->files()->name('*.php')->in($path) as $file) {
-                require_once $file->getRealPath();
+                require $file->getRealPath();
             }
         }
 


### PR DESCRIPTION
Using `require_once` prevent PHPUnit from loading the factory files multiple times for each test.