### PR TITLE
Support older symfony/finder versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.2.5",
         "illuminate/macroable": "^8.0",
-        "symfony/finder": "^5.0"
+        "symfony/finder": "^3.3|^4.0|^5.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
### Current Behaviour 

I managed to make `laravel/legacy-factories` as an optional requirements with project supporting older Laravel version however notice Composer hang when installing on Laravel 6 (assuming the same with older version), it doesn't happen on Laravel 7.
 
<https://travis-ci.org/github/laravie/dhosa/jobs/680019775>
![Screenshot 2020-04-27 at 7 56 21 PM](https://user-images.githubusercontent.com/172966/80369647-35267580-88c1-11ea-83b9-0a7da32e94e8.png)

### Excepted behaviour

We should be able to install with Laravel 6 and based on my test it working as expected. 

https://travis-ci.org/github/laravie/dhosa/builds/680056017

<img width="702" alt="Screenshot 2020-04-27 at 8 02 31 PM" src="https://user-images.githubusercontent.com/172966/80370139-0eb50a00-88c2-11ea-9e9a-cf896657488a.png">

> I already check againsts Laravel Framework 5.5 and the code usage using `Symfony\Component\Finder\Finder` hasn't change from `3.3` to `5.x`.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>