### PR TITLE
Support PHP 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.1.3|^8.0",
         "illuminate/macroable": "^8.0",
         "symfony/finder": "^3.4|^4.0|^5.0"
     },


### PR DESCRIPTION
This PR just allows to use PHP7.1 because this code was extracted from old Laravel versions which supports it.
I don't see any benefit to force people to use fresher PHP version if this code may work same way on old versions.

For example when I tried to add this package to one of my packages which supports laravel `5.7.*|5.8.*|^6.0|^7.0|^8.0` I've got this issue:
![Screenshot from 2020-11-20 00-32-51](https://user-images.githubusercontent.com/1849174/99726740-f3148980-2ac7-11eb-9b45-24947c84fbf2.png)
