### PR TITLE
Support `symfony/finder` v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "illuminate/macroable": "^8.0|^9.0",
-        "symfony/finder": "^3.4|^4.0|^5.0"
+        "symfony/finder": "^3.4|^4.0|^5.0|^6.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
```bash
➜  orion git:orion-laravel-9 ✗ composer why-not "symfony/finder" "6.0.0"
laravel/framework         8.x-dev  requires  symfony/finder (^5.4)
laravel/legacy-factories  1.x-dev  requires  symfony/finder (^3.4|^4.0|^5.0)
```