### PR TITLE
Support all valid PHP classnames while generating factories

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -232,7 +232,7 @@ class Factory implements ArrayAccess
      */
     protected function isLegacyFactory(string $path)
     {
-        return ! preg_match("/class\s[A-Z+a-z]+ extends Factory/", file_get_contents($path));
+        return ! preg_match("/class\s[a-zA-Z0-9_\x80-\xff]+ extends Factory/", file_get_contents($path));
     }
 
     /**


### PR DESCRIPTION
I've a project that migrated from a Laravel <= 7 to 8+. I've maintaned old factories using this package.
While developing new features I've defined a class named `View360` and a new factory `View360Factory`.

When running tests I get error on class definition about the fact that `View360Factory` is already defined.

Looking closer at the issue I've found that `legacy-factories` check the new factory validity using a subset of valid PHP classes.
From the [PHP docs](https://www.php.net/manual/en/language.oop5.basic.php), allowed characters are `[a-zA-Z0-9_\x80-\xff]` while this package only check `[a-zA-Z]`.
I've updated the regex check to include all valid classes.